### PR TITLE
Bug 2029416: UPSTREAM: 572: User credentials provided by CredentialsOperator

### DIFF
--- a/pkg/dbfs/dbfs.go
+++ b/pkg/dbfs/dbfs.go
@@ -77,8 +77,8 @@ func NewDriver(nodeID, endpoint string) *DBFS {
 	})
 
 	d.driver = csiDriver
-	accessKeyID, accessSecret, accessToken := utils.GetDefaultAK()
-	c := newDbfsClient(accessKeyID, accessSecret, accessToken, "")
+	accessControl := utils.GetAccessControl()
+	c := newDbfsClient(accessControl, "")
 	region := os.Getenv("REGION_ID")
 	if region == "" {
 		region, _ = utils.GetMetaData(RegionTag)

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -111,12 +111,12 @@ func NewDriver(nodeID, endpoint string, runAsController bool) *DISK {
 	tmpdisk.driver.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER})
 
 	// Init ECS Client
-	accessKeyID, accessSecret, accessToken := utils.GetDefaultAK()
-	client := newEcsClient(accessKeyID, accessSecret, accessToken)
-	if accessToken == "" {
-		log.Infof("Starting csi-plugin without sts")
+	accessControl := utils.GetAccessControl()
+	client := newEcsClient(accessControl)
+	if accessControl.UseMode == utils.EcsRAMRole || accessControl.UseMode == utils.ManagedToken {
+		log.Infof("Starting csi-plugin with sts.")
 	} else {
-		log.Infof("Starting csi-plugin with sts")
+		log.Infof("Starting csi-plugin without sts.")
 	}
 
 	// Set Region ID

--- a/pkg/local/utils.go
+++ b/pkg/local/utils.go
@@ -90,8 +90,8 @@ func getLocalDeviceNum() (int, error) {
 	instanceID := GetMetaData(InstanceID)
 	regionID := GetMetaData(RegionIDTag)
 	localDeviceNum := 0
-	akID, akSecret, token := utils.GetDefaultAK()
-	client := utils.NewEcsClient(akID, akSecret, token)
+	ac := utils.GetAccessControl()
+	client := utils.NewEcsClient(ac)
 
 	// Get Instance Type
 	request := ecs.CreateDescribeInstancesRequest()

--- a/pkg/lvm/utils.go
+++ b/pkg/lvm/utils.go
@@ -117,8 +117,8 @@ func getLocalDeviceNum() (int, error) {
 	instanceID := GetMetaData(InstanceID)
 	regionID := GetMetaData(RegionIDTag)
 	localDeviceNum := 0
-	akID, akSecret, token := utils.GetDefaultAK()
-	client := utils.NewEcsClient(akID, akSecret, token)
+	ac := utils.GetAccessControl()
+	client := utils.NewEcsClient(ac)
 
 	// Get Instance Type
 	request := ecs.CreateDescribeInstancesRequest()

--- a/pkg/nas/nas.go
+++ b/pkg/nas/nas.go
@@ -94,8 +94,8 @@ func NewDriver(nodeID, endpoint string) *NAS {
 	GlobalConfigSet()
 
 	d.driver = csiDriver
-	accessKeyID, accessSecret, accessToken := utils.GetDefaultAK()
-	c := newNasClient(accessKeyID, accessSecret, accessToken, "")
+	ac := utils.GetAccessControl()
+	c := newNasClient(ac, "")
 	region := os.Getenv("REGION_ID")
 	limit := os.Getenv("NAS_LIMIT_PERSECOND")
 	if limit == "" {

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -188,9 +188,9 @@ func GetMetaData(resource string) string {
 }
 
 func updateNasClient(client *aliNas.Client, regionID string) *aliNas.Client {
-	accessKeyID, accessSecret, accessToken := utils.GetDefaultAK()
-	if accessToken != "" {
-		client = newNasClient(accessKeyID, accessSecret, accessToken, regionID)
+	ac := utils.GetAccessControl()
+	if ac.UseMode == utils.EcsRAMRole || ac.UseMode == utils.ManagedToken {
+		client = newNasClient(ac, regionID)
 	}
 	if client.Client.GetConfig() != nil {
 		client.Client.GetConfig().UserAgent = KubernetesAlicloudIdentity
@@ -198,21 +198,22 @@ func updateNasClient(client *aliNas.Client, regionID string) *aliNas.Client {
 	return client
 }
 
-func newNasClient(accessKeyID, accessKeySecret, accessToken, regionID string) (nasClient *aliNas.Client) {
-	var err error
-	if regionID == "" {
+func newNasClient(ac utils.AccessControl, regionID string) (nasClient *aliNas.Client) {
+	if len(regionID) == 0 {
 		regionID = GetMetaData(RegionTag)
 	}
-	if accessToken == "" {
-		nasClient, err = aliNas.NewClientWithAccessKey(regionID, accessKeyID, accessKeySecret)
-		if err != nil {
-			return nil
-		}
-	} else {
-		nasClient, err = aliNas.NewClientWithStsToken(regionID, accessKeyID, accessKeySecret, accessToken)
-		if err != nil {
-			return nil
-		}
+	var err error
+	switch ac.UseMode {
+	case utils.AccessKey:
+		nasClient, err = aliNas.NewClientWithAccessKey(regionID, ac.AccessKeyID, ac.AccessKeySecret)
+	case utils.Credential:
+		nasClient, err = aliNas.NewClientWithOptions(regionID, ac.Config, ac.Credential)
+	default:
+		nasClient, err = aliNas.NewClientWithStsToken(regionID, ac.AccessKeyID, ac.AccessKeySecret, ac.StsToken)
+	}
+
+	if err != nil {
+		return nil
 	}
 
 	// Set Nas Endpoint

--- a/pkg/oss/nodeserver.go
+++ b/pkg/oss/nodeserver.go
@@ -233,7 +233,9 @@ func checkOssOptions(opt *Options) error {
 
 	// if not input ak from user, use the default ak value
 	if opt.AkID == "" || opt.AkSecret == "" {
-		opt.AkID, opt.AkSecret = utils.GetLocalAK()
+		ac := utils.GetLocalAK()
+		opt.AkID = ac.AccessKeyID
+		opt.AkSecret = ac.AccessKeySecret
 	}
 	if opt.AkID == "" || opt.AkSecret == "" {
 		if opt.AuthType == "" {

--- a/pkg/utils/auth.go
+++ b/pkg/utils/auth.go
@@ -17,16 +17,31 @@ limitations under the License.
 package utils
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/credentials"
 	"io/ioutil"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials/provider"
 )
 
 const (
@@ -46,96 +61,169 @@ type AKInfo struct {
 	Expiration string `json:"expiration"`
 	// Keyring key ring
 	Keyring string `json:"keyring"`
+	// RoleAccessKeyId key
+	RoleAccessKeyID string `json:"role.access.key.id"`
+	// RoleAccessKeySecret key
+	RoleAccessKeySecret string `json:"role.access.key.secret"`
+	// RoleArn key
+	RoleArn string `json:"role.arn"`
 }
 
-// GetDefaultAK read default ak from local file or from STS
-func GetDefaultAK() (string, string, string) {
-	accessKeyID, accessSecret := GetLocalAK()
+// ManageTokens 定义资源账号 和 角色扮演账号
+type ManageTokens struct {
+	// AccessKeyId key
+	AccessKeyID string
+	// AccessKeySecret key
+	AccessKeySecret string
+	// SecurityToken key
+	SecurityToken string
 
-	accessToken := ""
-	if accessKeyID == "" || accessSecret == "" {
-		accessKeyID, accessSecret, accessToken = GetManagedToken()
-		if accessKeyID != "" {
-			log.Infof("Get AK: use Managed AK")
-		}
-	} else {
-		log.Infof("Get AK: use Local AK")
+	// RoleAccessKeyId key
+	RoleAccessKeyID string
+	// RoleAccessKeySecret key
+	RoleAccessKeySecret string
+	// RoleArn key
+	RoleArn string
+}
+
+// KeyPairArtifacts is cert struct
+type KeyPairArtifacts struct {
+	Cert    *x509.Certificate
+	Key     *rsa.PrivateKey
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+// CertOption is cert option
+type CertOption struct {
+	CAName          string
+	CAOrganizations []string
+	DNSNames        []string
+	CommonName      string
+}
+
+// AccessControlMode is int, represents different modes
+type AccessControlMode int
+
+// AccessControlMode includes AccessKey, ManagedToken, EcsRamRole, Credential, RoleArnToken, five types of access control
+const (
+	AccessKey AccessControlMode = iota
+	ManagedToken
+	EcsRAMRole
+	Credential
+	RoleArnToken
+)
+
+// AccessControl is access control option
+type AccessControl struct {
+	AccessKeyID     string
+	AccessKeySecret string
+	StsToken        string
+	RoleArn         string
+	Config          *sdk.Config
+	Credential      auth.Credential
+	UseMode         AccessControlMode
+}
+
+func getAddonToken() AccessControl {
+	tokens := getManagedToken()
+	return AccessControl{AccessKeyID: tokens.AccessKeyID, AccessKeySecret: tokens.AccessKeySecret, StsToken: tokens.SecurityToken, UseMode: ManagedToken}
+}
+
+// GetAccessControl  1、Read default ak from local file. 2、If local default ak is not exist, then read from STS.
+func GetAccessControl() AccessControl {
+	//1、Get AK from Env
+	acLocalAK := GetLocalAK()
+	if len(acLocalAK.AccessKeyID) != 0 && len(acLocalAK.AccessKeySecret) != 0 {
+		log.Info("Get AK: use Local AK")
+		return acLocalAK
 	}
 
-	if accessKeyID == "" || accessSecret == "" {
-		accessKeyID, accessSecret, accessToken = GetSTSAK()
-		log.Infof("Get AK: use STS")
+	//2、Get AK from Credential Files
+	acCredentialAK := getCredentialAK()
+	if acCredentialAK.Config != nil && acCredentialAK.Credential != nil {
+		log.Info("Get AK: use Credential AK")
+		return acCredentialAK
 	}
 
-	return accessKeyID, accessSecret, accessToken
+	//3、Get AK from ManagedToken
+	acAddonToken := getAddonToken()
+	if len(acAddonToken.AccessKeyID) != 0 {
+		log.Info("Get AK: use Addon Token")
+		return acAddonToken
+	}
+
+	//4、Get AK from StsToken
+	acStsToken := getStsToken()
+	log.Info("Get AK: use Sts Token")
+	return acStsToken
 }
 
 // GetLocalAK read ossfs ak from local or from secret file
-func GetLocalAK() (string, string) {
+func GetLocalAK() AccessControl {
 	accessKeyID, accessSecret := "", ""
 	accessKeyID = os.Getenv("ACCESS_KEY_ID")
 	accessSecret = os.Getenv("ACCESS_KEY_SECRET")
 
-	return strings.TrimSpace(accessKeyID), strings.TrimSpace(accessSecret)
+	return AccessControl{AccessKeyID: strings.TrimSpace(accessKeyID), AccessKeySecret: strings.TrimSpace(accessSecret), UseMode: AccessKey}
 }
 
-// GetSTSAK get STS AK and token from ecs meta server
-func GetSTSAK() (string, string, string) {
+// GetStsToken get STS token and token from ecs meta server
+func getStsToken() AccessControl {
 	roleAuth := RoleAuth{}
 	subpath := "ram/security-credentials/"
 	roleName, err := GetMetaData(subpath)
 	if err != nil {
 		log.Errorf("GetSTSToken: request roleName with error: %s", err.Error())
-		return "", "", ""
+		return AccessControl{}
 	}
 
 	fullPath := filepath.Join(subpath, roleName)
 	roleInfo, err := GetMetaData(fullPath)
 	if err != nil {
 		log.Errorf("GetSTSToken: request roleInfo with error: %s", err.Error())
-		return "", "", ""
+		return AccessControl{}
 	}
 
 	err = json.Unmarshal([]byte(roleInfo), &roleAuth)
 	if err != nil {
 		log.Errorf("GetSTSToken: unmarshal roleInfo: %s, with error: %s", roleInfo, err.Error())
-		return "", "", ""
+		return AccessControl{}
 	}
-	return roleAuth.AccessKeyID, roleAuth.AccessKeySecret, roleAuth.SecurityToken
+	return AccessControl{AccessKeyID: roleAuth.AccessKeyID, AccessKeySecret: roleAuth.AccessKeySecret, StsToken: roleAuth.SecurityToken, UseMode: EcsRAMRole}
 }
 
 // GetManagedToken get ak from csi secret
-func GetManagedToken() (string, string, string) {
+func getManagedToken() (tokens ManageTokens) {
 	var akInfo AKInfo
-	AccessKeyID, AccessKeySecret, SecurityToken := "", "", ""
 	if _, err := os.Stat(ConfigPath); err == nil {
 		encodeTokenCfg, err := ioutil.ReadFile(ConfigPath)
 		if err != nil {
 			log.Errorf("failed to read token config, err: %v", err)
-			return "", "", ""
+			return ManageTokens{}
 		}
 		err = json.Unmarshal(encodeTokenCfg, &akInfo)
 		if err != nil {
 			log.Errorf("error unmarshal token config: %v", err)
-			return "", "", ""
+			return ManageTokens{}
 		}
 		keyring := akInfo.Keyring
 		ak, err := Decrypt(akInfo.AccessKeyID, []byte(keyring))
 		if err != nil {
 			log.Errorf("failed to decode ak, err: %v", err)
-			return "", "", ""
+			return ManageTokens{}
 		}
 
 		sk, err := Decrypt(akInfo.AccessKeySecret, []byte(keyring))
 		if err != nil {
 			log.Errorf("failed to decode sk, err: %v", err)
-			return "", "", ""
+			return ManageTokens{}
 		}
 
 		token, err := Decrypt(akInfo.SecurityToken, []byte(keyring))
 		if err != nil {
 			log.Errorf("failed to decode token, err: %v", err)
-			return "", "", ""
+			return ManageTokens{}
 		}
 		layout := "2006-01-02T15:04:05Z"
 		t, err := time.Parse(layout, akInfo.Expiration)
@@ -145,11 +233,27 @@ func GetManagedToken() (string, string, string) {
 		if t.Before(time.Now()) {
 			log.Errorf("invalid token which is expired, expiration as: %s", akInfo.Expiration)
 		}
-		AccessKeyID = string(ak)
-		AccessKeySecret = string(sk)
-		SecurityToken = string(token)
+		tokens.AccessKeyID = string(ak)
+		tokens.AccessKeySecret = string(sk)
+		tokens.SecurityToken = string(token)
+
+		if akInfo.RoleAccessKeyID != "" && akInfo.RoleAccessKeySecret != "" {
+			roleAK, err := Decrypt(akInfo.RoleAccessKeyID, []byte(keyring))
+			if err != nil {
+				log.Errorf("failed to decode role ak, err: %v", err)
+				return ManageTokens{}
+			}
+			roleSK, err := Decrypt(akInfo.RoleAccessKeySecret, []byte(keyring))
+			if err != nil {
+				log.Errorf("failed to decode role sk, err : %v", err)
+				return ManageTokens{}
+			}
+			tokens.RoleAccessKeyID = string(roleAK)
+			tokens.RoleAccessKeySecret = string(roleSK)
+		}
+		tokens.RoleArn = akInfo.RoleArn
 	}
-	return AccessKeyID, AccessKeySecret, SecurityToken
+	return tokens
 }
 
 // PKCS5UnPadding get pkc
@@ -181,4 +285,180 @@ func Decrypt(s string, keyring []byte) ([]byte, error) {
 
 	origData = PKCS5UnPadding(origData)
 	return origData, nil
+}
+
+// GetDefaultRoleAK  返回角色扮演账号AK, SK, role arn
+func GetDefaultRoleAK() AccessControl {
+	roleAccessKeyID, roleAccessKeySecret, roleArn := os.Getenv("ROLE_ACCESS_KEY_ID"), os.Getenv("ROLE_ACCESS_KEY_SECRET"), os.Getenv("ROLE_ARN")
+	if len(roleAccessKeyID) == 0 || len(roleAccessKeySecret) == 0 || len(roleArn) == 0 {
+		tokens := getManagedToken()
+		return AccessControl{AccessKeyID: tokens.RoleAccessKeyID, AccessKeySecret: tokens.RoleAccessKeySecret, RoleArn: tokens.RoleArn, UseMode: ManagedToken}
+	}
+	return AccessControl{AccessKeyID: roleAccessKeyID, AccessKeySecret: roleAccessKeySecret, RoleArn: roleArn, UseMode: RoleArnToken}
+}
+
+// CreateCACert function is create cacert
+func CreateCACert(option CertOption, begin, end time.Time) (*KeyPairArtifacts, error) {
+	templ := &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName:   option.CAName,
+			Organization: option.CAOrganizations,
+		},
+		DNSNames:              option.DNSNames,
+		NotBefore:             begin,
+		NotAfter:              end,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("generating key: %s", err)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, templ, templ, key.Public(), key)
+	if err != nil {
+		return nil, fmt.Errorf("creating certificate: %s", err)
+	}
+	certPEM, keyPEM, err := pemEncode(der, key)
+	if err != nil {
+		return nil, fmt.Errorf("encoding PEM: %s", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %s", err)
+	}
+
+	return &KeyPairArtifacts{Cert: cert, Key: key, CertPEM: certPEM, KeyPEM: keyPEM}, nil
+}
+
+// CreateCertPEM function is create cacert pem
+func CreateCertPEM(option CertOption, ca *KeyPairArtifacts, begin, end time.Time, isClient bool) ([]byte, []byte, error) {
+	sn, err := genSerialNum()
+	if err != nil {
+		return nil, nil, err
+	}
+	eks := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	dnsNames := option.DNSNames
+	if isClient {
+		eks = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		dnsNames = nil
+	}
+	templ := &x509.Certificate{
+		SerialNumber: sn,
+		Subject: pkix.Name{
+			CommonName: option.CommonName,
+		},
+		DNSNames:              dnsNames,
+		NotBefore:             begin,
+		NotAfter:              end,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           eks,
+		BasicConstraintsValid: true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generating key: %s", err)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, templ, ca.Cert, key.Public(), ca.Key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating certificate: %s", err)
+	}
+	certPEM, keyPEM, err := pemEncode(der, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encoding PEM: %s", err)
+	}
+	return certPEM, keyPEM, nil
+}
+
+func pemEncode(certificateDER []byte, key *rsa.PrivateKey) ([]byte, []byte, error) {
+	certBuf := &bytes.Buffer{}
+	if err := pem.Encode(certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certificateDER}); err != nil {
+		return nil, nil, fmt.Errorf("encoding cert: %s", err)
+	}
+	keyBuf := &bytes.Buffer{}
+	if err := pem.Encode(keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return nil, nil, fmt.Errorf("encoding key: %s", err)
+	}
+	return certBuf.Bytes(), keyBuf.Bytes(), nil
+}
+
+func genSerialNum() (*big.Int, error) {
+	serialNumLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNum, err := rand.Int(rand.Reader, serialNumLimit)
+	if err != nil {
+		return nil, fmt.Errorf("serial number generation failure (%v)", err)
+	}
+	return serialNum, nil
+}
+
+// NewClientTLSFromFile function is new client with tls
+func NewClientTLSFromFile(serverName, caFile, certFile, keyFile string) (credentials.TransportCredentials, error) {
+	// Load the certificates from disk
+	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not load server key pair: %s", err)
+	}
+
+	// Create a certificate pool from the certificate authority
+	certPool := x509.NewCertPool()
+	ca, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read ca certificate: %s", err)
+	}
+
+	// Append the client certificates from the CA
+	if ok := certPool.AppendCertsFromPEM(ca); !ok {
+		return nil, errors.New("failed to append client certs")
+	}
+
+	// Create the TLS credentials
+	creds := credentials.NewTLS(&tls.Config{
+		ServerName:   serverName,
+		Certificates: []tls.Certificate{certificate},
+		RootCAs:      certPool,
+	})
+	return creds, nil
+}
+
+// NewServerTLSFromFile function is new server with tls
+func NewServerTLSFromFile(caFile, certFile, keyFile string) (credentials.TransportCredentials, error) {
+	// Load the certificates from disk
+	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not load server key pair: %s", err)
+	}
+
+	// Create a certificate pool from the certificate authority
+	certPool := x509.NewCertPool()
+	ca, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read ca certificate: %s", err)
+	}
+
+	// Append the client certificates from the CA
+	if ok := certPool.AppendCertsFromPEM(ca); !ok {
+		return nil, errors.New("failed to append client certs")
+	}
+
+	// Create the TLS credentials
+	creds := credentials.NewTLS(&tls.Config{
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		Certificates: []tls.Certificate{certificate},
+		ClientCAs:    certPool,
+	})
+	return creds, nil
+}
+
+// getCredentialAK get credential and config from credential files.
+func getCredentialAK() AccessControl {
+	envProvider := provider.NewEnvProvider()
+	profileProvider := provider.NewProfileProvider()
+	pc := provider.NewProviderChain([]provider.Provider{envProvider, profileProvider})
+	credential, err := pc.Resolve()
+	if err != nil {
+		log.Errorf("Failed to resolve an authentication provider: %v", err)
+	}
+	config := sdk.NewConfig().WithScheme("https")
+	return AccessControl{Config: config, Credential: credential, UseMode: Credential}
 }

--- a/pkg/utils/auth_test.go
+++ b/pkg/utils/auth_test.go
@@ -23,19 +23,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetDefaultAK(t *testing.T) {
+func TestGetAccessControl(t *testing.T) {
 	testAccessKey := "testkey"
 	testAccessKeySecret := "testvalue"
 	os.Setenv("ACCESS_KEY_ID", testAccessKey)
 	os.Setenv("ACCESS_KEY_SECRET", testAccessKeySecret)
-	accessKeyID, accessKeySecret, accessToken := GetDefaultAK()
-	assert.Equal(t, testAccessKey, accessKeyID)
-	assert.Equal(t, testAccessKeySecret, accessKeySecret)
-	assert.Empty(t, accessToken)
+	ac := GetAccessControl()
+	assert.Equal(t, testAccessKey, ac.AccessKeyID)
+	assert.Equal(t, testAccessKeySecret, ac.AccessKeySecret)
+	assert.Empty(t, ac.StsToken)
 	os.Unsetenv("ACCESS_KEY_ID")
 	os.Unsetenv("ACCESS_KEY_SECRET")
-	accessKeyID, accessKeySecret, accessToken = GetDefaultAK()
-	assert.Empty(t, accessKeyID)
-	assert.Empty(t, accessKeySecret)
-	assert.Empty(t, accessToken)
+	ac = GetAccessControl()
+	assert.Empty(t, ac.AccessKeyID)
+	assert.Empty(t, ac.AccessKeySecret)
+	assert.Empty(t, ac.StsToken)
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -305,18 +305,20 @@ func ReadJSONFile(file string) (map[string]string, error) {
 }
 
 // NewEcsClient create a ecsClient object
-func NewEcsClient(accessKeyID, accessKeySecret, accessToken string) (ecsClient *ecs.Client) {
+func NewEcsClient(ac AccessControl) (ecsClient *ecs.Client) {
 	var err error
-	if accessToken == "" {
-		ecsClient, err = ecs.NewClientWithAccessKey(DefaultRegion, accessKeyID, accessKeySecret)
-		if err != nil {
-			return nil
-		}
-	} else {
-		ecsClient, err = ecs.NewClientWithStsToken(DefaultRegion, accessKeyID, accessKeySecret, accessToken)
-		if err != nil {
-			return nil
-		}
+	switch ac.UseMode {
+	case AccessKey:
+		ecsClient, err = ecs.NewClientWithAccessKey(DefaultRegion, ac.AccessKeyID, ac.AccessKeySecret)
+	case Credential:
+		ecsClient, err = ecs.NewClientWithOptions(DefaultRegion, ac.Config, ac.Credential)
+	default:
+		ecsClient, err = ecs.NewClientWithStsToken(DefaultRegion, ac.AccessKeyID, ac.AccessKeySecret, ac.StsToken)
+
+	}
+
+	if err != nil {
+		return nil
 	}
 	return
 }


### PR DESCRIPTION
This is heavily tailored patch from [upstream](https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/pull/572), I basically took `pkg/utils/auth.go` from master.

I can see:
* In the driver logs:
    *  With this PR:
        ```
        time="2022-01-20T10:24:40Z" level=info msg="Get AK: use Credential AK"
        ```
    * Before this PR:
        ```
        time="2022-01-20T11:01:08Z" level=info msg="Get AK: use STS"
        ```
* When I provision a volume, in Alibaba cloud logs (Elastic Compute Service -> Operation Logs):
    * With this PR:
        * Operation Name: CreateDisk
        * User Name: jsafrane-1-28wl2-openshift-cluster-csi-drivers-alibaba-disk-cred
    * Before this PR:
        * Operation Name: CreateDisk
        * User Name: jsafrane-1-28wl2-role-master:vm-ram-i-gw8h04yo5307lunypvo3
        * (i.e. Node's identity is used to provision the volume)
  
cc @openshift/storage 