### PR TITLE
Bug 2076671: 4.10: Add a parameter to the schema to automatically increase volume sizes

### DIFF
--- a/pkg/disk/utils.go
+++ b/pkg/disk/utils.go
@@ -1066,6 +1066,19 @@ func getDiskVolumeOptions(req *csi.CreateVolumeRequest) (*diskVolumeArgs, error)
 		diskVolArgs.ResourceGroupID = ""
 	}
 
+	// volumeSizeAutoAvailable
+	value, ok = volOptions["volumeSizeAutoAvailable"]
+	if !ok {
+		diskVolArgs.VolumeSizeAutoAvailable = false
+	} else {
+		value = strings.ToLower(value)
+		if value == "yes" || value == "true" || value == "1" {
+			diskVolArgs.VolumeSizeAutoAvailable = true
+		} else {
+			diskVolArgs.VolumeSizeAutoAvailable = false
+		}
+	}
+
 	return diskVolArgs, nil
 }
 


### PR DESCRIPTION
This is cherry-pick of https://github.com/openshift/alibaba-cloud-csi-driver/pull/12 that allows OCP to automatically increase PVC size to 20GiB, which is the minimum disk size supported by Alibaba.

cc @openshift/storage 