### PR TITLE
OCPBUGS-6222: UPSTREAM: 682: fix gofmt

### DIFF
--- a/pkg/cnfs/v1beta1/base.go
+++ b/pkg/cnfs/v1beta1/base.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-//getCnfsObject get cnfs crd
+// getCnfsObject get cnfs crd
 func getCnfsObject(client dynamic.Interface, name string) (*ContainerNetworkFileSystem, error) {
 	utd, err := client.Resource(GVR).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
@@ -30,7 +30,7 @@ func getCnfsObject(client dynamic.Interface, name string) (*ContainerNetworkFile
 	return &cnfs, nil
 }
 
-//GetCnfsObject get cnfs's object
+// GetCnfsObject get cnfs's object
 func GetCnfsObject(client dynamic.Interface, name string) (*ContainerNetworkFileSystem, error) {
 	cnfsObj, err := getCnfsObject(client, name)
 	if err != nil {

--- a/pkg/cnfs/v1beta1/types.go
+++ b/pkg/cnfs/v1beta1/types.go
@@ -5,14 +5,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-//GVR is cnfs version
+// GVR is cnfs version
 var GVR = schema.GroupVersionResource{
 	Group:    "storage.alibabacloud.com",
 	Version:  "v1beta1",
 	Resource: "containernetworkfilesystems",
 }
 
-//ContainerNetworkFileSystem define cnfs crd
+// ContainerNetworkFileSystem define cnfs crd
 type ContainerNetworkFileSystem struct {
 	metaV1.TypeMeta   `json:",inline"`
 	metaV1.ObjectMeta `json:"metadata,omitempty"`
@@ -21,21 +21,21 @@ type ContainerNetworkFileSystem struct {
 	Status ContainerNetworkFileSystemStatus `json:"status,omitempty"`
 }
 
-//ContainerNetworkFileSystemStatus define cnfs status field
+// ContainerNetworkFileSystemStatus define cnfs status field
 type ContainerNetworkFileSystemStatus struct {
 	Status       string                                `json:"status,omitempty"`
 	FsAttributes FsAttributes                          `json:"fsAttributes,omitempty"`
 	Conditions   []ContainerNetworkFileSystemCondition `json:"conditions,omitempty"`
 }
 
-//ContainerNetworkFileSystemCondition define cnfs condition field
+// ContainerNetworkFileSystemCondition define cnfs condition field
 type ContainerNetworkFileSystemCondition struct {
 	LastProbeTime string `json:"lastProbeTime,omitempty"`
 	Status        string `json:"status,omitempty"`
 	Reason        string `json:"reason,omitempty"`
 }
 
-//ContainerNetworkFileSystemSpec define cnfs spec field
+// ContainerNetworkFileSystemSpec define cnfs spec field
 type ContainerNetworkFileSystemSpec struct {
 	StorageType   string     `json:"type,omitempty"`
 	ReclaimPolicy string     `json:"reclaimPolicy,omitempty"`
@@ -43,7 +43,7 @@ type ContainerNetworkFileSystemSpec struct {
 	Parameters    Parameters `json:"parameters,omitempty"`
 }
 
-//FsAttributes define cnfs status FsAttributes field
+// FsAttributes define cnfs status FsAttributes field
 type FsAttributes struct {
 	RegionID             string    `json:"regionId,omitempty"`
 	ZoneID               string    `json:"zoneId,omitempty"`
@@ -63,13 +63,13 @@ type FsAttributes struct {
 	TrashCanReservedDays string    `json:"trashCanReservedDays,omitempty"`
 }
 
-//EndPoint define cnfs endpoint field when cnfs type is oss
+// EndPoint define cnfs endpoint field when cnfs type is oss
 type EndPoint struct {
 	Internal string `json:"internal,omitempty"`
 	Extranet string `json:"extranet,omitempty"`
 }
 
-//Parameters define cnfs parameters field
+// Parameters define cnfs parameters field
 type Parameters struct {
 	Secret               *Secret `json:"secret,omitempty"`
 	StorageType          string  `json:"storageType,omitempty"`
@@ -84,13 +84,13 @@ type Parameters struct {
 	TrashCanReservedDays string  `json:"trashCanReservedDays,omitempty"`
 }
 
-//Secret define secret field
+// Secret define secret field
 type Secret struct {
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,,omitempty"`
 }
 
-//ContainerNetworkFileSystemList define cnfs list
+// ContainerNetworkFileSystemList define cnfs list
 type ContainerNetworkFileSystemList struct {
 	metaV1.TypeMeta `json:",inline"`
 	metaV1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/cpfs/controllerserver.go
+++ b/pkg/cpfs/controllerserver.go
@@ -309,7 +309,6 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	return &csi.ControllerPublishVolumeResponse{}, nil
 }
 
-//
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	log.Infof("CreateSnapshot is called, do nothing now")
 	return &csi.CreateSnapshotResponse{}, nil

--- a/pkg/cpfs/utils.go
+++ b/pkg/cpfs/utils.go
@@ -95,7 +95,7 @@ func GetCpfsDetails(cpfsServersString string) (string, string, string) {
 	return cpfsServer, cpfsFileSystem, cpfsPath
 }
 
-//CreateDest create the target
+// CreateDest create the target
 func CreateDest(dest string) error {
 	fi, err := os.Lstat(dest)
 	if os.IsNotExist(err) {
@@ -112,7 +112,7 @@ func CreateDest(dest string) error {
 	return nil
 }
 
-//DoMount execute the mount command for cpfs dir
+// DoMount execute the mount command for cpfs dir
 func DoMount(cpfsServer, cpfsFileSystem, cpfsPath, mountOptions, mountPoint, volumeID string) error {
 	if !utils.IsFileExisting(mountPoint) {
 		CreateDest(mountPoint)

--- a/pkg/dbfs/controllerserver.go
+++ b/pkg/dbfs/controllerserver.go
@@ -364,7 +364,6 @@ func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
-//
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	log.Infof("CreateSnapshot is called, do nothing now")
 	return &csi.CreateSnapshotResponse{}, nil

--- a/pkg/dbfs/dbfs.go
+++ b/pkg/dbfs/dbfs.go
@@ -56,7 +56,7 @@ type DBFS struct {
 	cscap []*csi.ControllerServiceCapability
 }
 
-//NewDriver create the identity/node/controller server and dbfs driver
+// NewDriver create the identity/node/controller server and dbfs driver
 func NewDriver(nodeID, endpoint string) *DBFS {
 	log.Infof("Driver: %v version: %v", driverName, version)
 

--- a/pkg/dbfs/nodeserver.go
+++ b/pkg/dbfs/nodeserver.go
@@ -60,7 +60,7 @@ const (
 	DdbfROOT = "/mnt/dbfs/"
 )
 
-//newNodeServer create the csi node server
+// newNodeServer create the csi node server
 func newNodeServer(d *DBFS) *nodeServer {
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -92,7 +92,7 @@ var (
 func initDriver() {
 }
 
-//NewDriver create the identity/node/controller server and disk driver
+// NewDriver create the identity/node/controller server and disk driver
 func NewDriver(nodeID, endpoint string, runAsController bool) *DISK {
 	initDriver()
 	tmpdisk := &DISK{}

--- a/pkg/disk/utils_test.go
+++ b/pkg/disk/utils_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/local/client/grpc.go
+++ b/pkg/local/client/grpc.go
@@ -63,7 +63,6 @@ type NameSpaceOptions struct {
 	Size   uint64
 }
 
-//
 type workerConnection struct {
 	conn             *grpc.ClientConn
 	mountPathWithTLS string

--- a/pkg/metric/collector.go
+++ b/pkg/metric/collector.go
@@ -38,7 +38,7 @@ type CSICollector struct {
 	Collectors map[string]Collector
 }
 
-//newCSICollector method returns the CSICollector object
+// newCSICollector method returns the CSICollector object
 func newCSICollector() error {
 	if csiCollectorInstance == nil {
 		collectors := make(map[string]Collector)
@@ -112,7 +112,7 @@ func execute(name string, c Collector, ch chan<- prometheus.Metric) {
 // ErrNoData indicates the collector found no data to collect, but had no other error.
 var ErrNoData = errors.New("Collector returned no data")
 
-//IsNoDataError method is to determine whether the Collector has no data to return
+// IsNoDataError method is to determine whether the Collector has no data to return
 func IsNoDataError(err error) bool {
 	return err == ErrNoData
 }

--- a/pkg/metric/common.go
+++ b/pkg/metric/common.go
@@ -66,8 +66,8 @@ const (
 
 type collectorFactoryFunc = func() (Collector, error)
 
-//csiCollectorInstance is a single instance of CSICollector
-//Factories are the mapping between monitoring types and collectorFactoryFunc
+// csiCollectorInstance is a single instance of CSICollector
+// Factories are the mapping between monitoring types and collectorFactoryFunc
 var (
 	csiCollectorInstance *CSICollector
 	factories            = make(map[string]collectorFactoryFunc)

--- a/pkg/metric/http.go
+++ b/pkg/metric/http.go
@@ -14,19 +14,19 @@ const (
 	metricPath   = "metrics"
 )
 
-//HTTPClient is http client with server client
+// HTTPClient is http client with server client
 type HTTPClient struct {
 	url    string
 	client *http.Client
 }
 
-//getURL to get the corresponding url
+// getURL to get the corresponding url
 func getURL(httpProtocol string, dnsName string, port string, metricPath string) string {
 	url := httpProtocol + "://" + dnsName + ":" + port + "/" + metricPath
 	return url
 }
 
-//NewHTTPClient to create http client
+// NewHTTPClient to create http client
 func NewHTTPClient() *HTTPClient {
 	url := getURL(httpProtocol, dnsName, port, metricPath)
 	client := &http.Client{}
@@ -34,7 +34,7 @@ func NewHTTPClient() *HTTPClient {
 	return &HTTPClient{url, client}
 }
 
-//Get to get response from server with http client
+// Get to get response from server with http client
 func (h *HTTPClient) Get(key string, val string) (*http.Response, error) {
 	url := h.url + "?" + key + "=" + val
 	resp, err := h.client.Get(url)
@@ -45,7 +45,7 @@ func (h *HTTPClient) Get(key string, val string) (*http.Response, error) {
 	return resp, nil
 }
 
-//ReadBody to read body from response
+// ReadBody to read body from response
 func (h *HTTPClient) ReadBody(response *http.Response) string {
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -55,7 +55,7 @@ func (h *HTTPClient) ReadBody(response *http.Response) string {
 	return string(body)
 }
 
-//Close to close response
+// Close to close response
 func (h *HTTPClient) Close(response *http.Response) {
 	if response != nil {
 		_ = response.Body.Close()

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 )
 
-//Handler is a package of promHttp,metric entry
+// Handler is a package of promHttp,metric entry
 type Handler struct {
 }
 
@@ -37,7 +37,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handler.ServeHTTP(w, r)
 }
 
-//NewMetricHandler method returns a promHttp object
+// NewMetricHandler method returns a promHttp object
 func NewMetricHandler(serviceType string) *Handler {
 
 	setServiceType(serviceType)

--- a/pkg/metric/mountstats.go
+++ b/pkg/metric/mountstats.go
@@ -293,7 +293,8 @@ func parseMountStats(r io.Reader) ([]*Mount, error) {
 }
 
 // parseMount parses an entry in /proc/[pid]/mountstats in the format:
-//   device [device] mounted on [mount] with fstype [type]
+//
+//	device [device] mounted on [mount] with fstype [type]
 func parseMount(ss []string) (*Mount, error) {
 	if len(ss) < deviceEntryLen {
 		return nil, fmt.Errorf("invalid device entry: %v", ss)

--- a/pkg/metric/pfsstat_collector.go
+++ b/pkg/metric/pfsstat_collector.go
@@ -265,10 +265,10 @@ func findVolJSONByPfsRawBlock(rootDir string) ([]string, error) {
 	return resDir, err
 }
 
-//1.find pv
-//2.find pod id by pv
-//3.pod is running?
-//4.find docker id by pod id
+// 1.find pv
+// 2.find pod id by pv
+// 3.pod is running?
+// 4.find docker id by pod id
 func getPfsRawBlockStats(dockerClient **client.Client) (map[string][]string, error) {
 	pvNameArray, err := getPfsRawBlockPvName()
 	if pvNameArray == nil && err.Error() == notFoundvolumeDevices {

--- a/pkg/nas/controllerserver.go
+++ b/pkg/nas/controllerserver.go
@@ -939,7 +939,6 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	return &csi.ControllerPublishVolumeResponse{}, nil
 }
 
-//
 func (cs *controllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	log.Infof("CreateSnapshot is called, do nothing now")
 	return &csi.CreateSnapshotResponse{}, nil

--- a/pkg/nas/nas.go
+++ b/pkg/nas/nas.go
@@ -72,7 +72,7 @@ type NAS struct {
 	cscap []*csi.ControllerServiceCapability
 }
 
-//NewDriver create the identity/node/controller server and disk driver
+// NewDriver create the identity/node/controller server and disk driver
 func NewDriver(nodeID, endpoint string) *NAS {
 	log.Infof("Driver: %v version: %v", driverName, version)
 

--- a/pkg/nas/nodeserver.go
+++ b/pkg/nas/nodeserver.go
@@ -87,7 +87,7 @@ const (
 	NasMntPoint = "/mnt/nasplugin.alibabacloud.com"
 )
 
-//newNodeServer create the csi node server
+// newNodeServer create the csi node server
 func newNodeServer(d *NAS) *nodeServer {
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {

--- a/pkg/nas/nodeserver_test.go
+++ b/pkg/nas/nodeserver_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/nas/utils.go
+++ b/pkg/nas/utils.go
@@ -77,7 +77,7 @@ type RoleAuth struct {
 	Code            string
 }
 
-//DoNfsMount execute the mount command for nas dir
+// DoNfsMount execute the mount command for nas dir
 func DoNfsMount(nfsServer, nfsPath, nfsVers, mountOptions, mountPoint, volumeID string) error {
 	if !utils.IsFileExisting(mountPoint) {
 		CreateDest(mountPoint)
@@ -113,7 +113,7 @@ func DoNfsMount(nfsServer, nfsPath, nfsVers, mountOptions, mountPoint, volumeID 
 	return nil
 }
 
-//CheckNfsPathMounted check whether the given nfs path was mounted
+// CheckNfsPathMounted check whether the given nfs path was mounted
 func CheckNfsPathMounted(mountpoint, server, path string) bool {
 	// mntCmd := fmt.Sprintf("findmnt %s | grep %s | grep %s | grep -v grep | wc -l", mountpoint, server, path)
 	mntCmd := fmt.Sprintf("cat /proc/mounts | grep %s | grep %s | grep -v grep | wc -l", mountpoint, path)
@@ -124,7 +124,7 @@ func CheckNfsPathMounted(mountpoint, server, path string) bool {
 	return false
 }
 
-//CreateDest create the target
+// CreateDest create the target
 func CreateDest(dest string) error {
 	fi, err := os.Lstat(dest)
 	if os.IsNotExist(err) {
@@ -606,7 +606,7 @@ func isValidCnfsParameter(server string, cnfsName string) error {
 	return nil
 }
 
-//GetFsIDByServer func is get fsID from serverName
+// GetFsIDByServer func is get fsID from serverName
 func GetFsIDByServer(server string) string {
 	if len(server) == 0 {
 		return ""

--- a/pkg/oss/nodeserver_test.go
+++ b/pkg/oss/nodeserver_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -51,7 +51,7 @@ import (
 	"time"
 )
 
-//DefaultOptions used for global ak
+// DefaultOptions used for global ak
 type DefaultOptions struct {
 	Global struct {
 		KubernetesClusterTag string
@@ -108,12 +108,12 @@ type RoleAuth struct {
 	Code            string
 }
 
-//CreateEvent is create events
+// CreateEvent is create events
 func CreateEvent(recorder record.EventRecorder, objectRef *v1.ObjectReference, eventType string, reason string, err string) {
 	recorder.Event(objectRef, eventType, reason, err)
 }
 
-//NewEventRecorder is create snapshots event recorder
+// NewEventRecorder is create snapshots event recorder
 func NewEventRecorder() record.EventRecorder {
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -212,7 +212,7 @@ func CreateDest(dest string) error {
 	return nil
 }
 
-//IsLikelyNotMountPoint return status of mount point,this function fix IsMounted return 0 bug
+// IsLikelyNotMountPoint return status of mount point,this function fix IsMounted return 0 bug
 func IsLikelyNotMountPoint(file string) (bool, error) {
 	stat, err := os.Stat(file)
 	if err != nil {
@@ -279,7 +279,7 @@ func GetRegionAndInstanceID() (string, string, error) {
 	return regionID, instanceID, nil
 }
 
-//GetMetaData get metadata from ecs meta-server
+// GetMetaData get metadata from ecs meta-server
 func GetMetaData(resource string) (string, error) {
 	resp, err := http.Get(MetadataURL + resource)
 	if err != nil {
@@ -595,7 +595,7 @@ func Fsync(f *os.File) error {
 	return f.Sync()
 }
 
-//GetNodeAddr get node address
+// GetNodeAddr get node address
 func GetNodeAddr(client kubernetes.Interface, node string, port string) (string, error) {
 	ip, err := GetNodeIP(client, node)
 	if err != nil {
@@ -624,7 +624,7 @@ func GetNodeIP(client kubernetes.Interface, nodeID string) (net.IP, error) {
 	return nil, fmt.Errorf("Node IP unknown; known addresses: %v", addresses)
 }
 
-//CheckParameterValidate is check parameter validating in csi-plugin
+// CheckParameterValidate is check parameter validating in csi-plugin
 func CheckParameterValidate(inputs []string) bool {
 	for _, input := range inputs {
 		if matched, err := regexp.MatchString("^[A-Za-z0-9=._@:~/-]*$", input); err != nil || !matched {
@@ -634,7 +634,7 @@ func CheckParameterValidate(inputs []string) bool {
 	return true
 }
 
-//CheckQuotaPathValidate is check quota path validating in csi-plugin
+// CheckQuotaPathValidate is check quota path validating in csi-plugin
 func CheckQuotaPathValidate(kubeClient *kubernetes.Clientset, path string) error {
 	pvName := filepath.Base(path)
 	_, err := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
@@ -645,7 +645,7 @@ func CheckQuotaPathValidate(kubeClient *kubernetes.Clientset, path string) error
 	return nil
 }
 
-//IsHostFileExist is check host file is existing in lvm
+// IsHostFileExist is check host file is existing in lvm
 func IsHostFileExist(path string) bool {
 	args := []string{NsenterCmd, "stat", path}
 	cmd := strings.Join(args, " ")


### PR DESCRIPTION
Update gofmt of all files for go 1.19. It very roughly corresponds to upstream PR #682, but does not contain the metrics bugfix.

@openshift/storage 